### PR TITLE
s/lasterror/lastError/

### DIFF
--- a/background.js
+++ b/background.js
@@ -19,7 +19,7 @@ function scanHistory() {
 
     // Wow, this is an easy API.
     chrome.history.deleteRange({startTime: 0, endTime: maxTime},
-        function() { if (chrome.runtime.lasterror) { console.warn(chrome.runtime.lastError); } }
+        function() { if (chrome.runtime.lastError) { console.warn(chrome.runtime.lastError); } }
     );
 }
 


### PR DESCRIPTION
`lastError` is referenced lowercase as `lasterror`, and as JS is case-sensitive, this will cause it to always evaluate to false, and therefore never log anything.